### PR TITLE
update windows os version to rs5-pro

### DIFF
--- a/template.json
+++ b/template.json
@@ -17,7 +17,7 @@
         "LABVMAdminPassword": "Password.1!!",
         "LABVMImagePublisher": "MicrosoftWindowsDesktop",
         "LABVMImageOffer": "Windows-10",
-        "LABVMWindowsOSVersion": "RS3-Pro",
+        "LABVMWindowsOSVersion": "rs5-pro",
         "LABVMVmSize": "Standard_D2s_v3",
         "LABVMVnetID": "[resourceId('Microsoft.Network/virtualNetworks', 'LABVMVNET')]",
         "LABVMSubnetRef": "[concat(variables('LABVMVnetID'), '/subnets/', variables('LABVMVNETSubnet1Name'))]",


### PR DESCRIPTION
Rs3-Pro was throwing an error. 

Updated Rs3-Pro to rs5-pro. 

https://dev.azure.com/SI-CIM-Bootcamps/Azure%20DevOps%20Bootcamp/_wiki/wikis/Azure%20DevOps%20Bootcamp%20Wiki/122/Prerequisites